### PR TITLE
chore: upgrade github actions to v3 & node to 16.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,10 +4,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - run: npm install
       - run: npm test


### PR DESCRIPTION
This PR upgrade github actions to v3 & node to 16.x

[Jest 28 is compatible with node 16 (lts)](https://github.com/facebook/jest/blob/f5db241312f46528389e55c38221e6b6968622cf/package.json#L167)

 